### PR TITLE
fix(i18n): Correct Chinese translations for 'meta_password'

### DIFF
--- a/src-tauri/locales/zh-cn.json
+++ b/src-tauri/locales/zh-cn.json
@@ -287,7 +287,7 @@
     "is_sharepoint": "是否为SharePoint",
     "internal_upload": "内部上传",
     "site_id": "站点ID",
-    "meta_password": "原数据密码",
+    "meta_password": "元信息密码",
     "share_name": "分享名称",
     "account": "账号",
     "bearer_token": "Bearer Token",

--- a/src-tauri/locales/zh-hant.json
+++ b/src-tauri/locales/zh-hant.json
@@ -287,7 +287,7 @@
     "is_sharepoint": "是否為SharePoint",
     "internal_upload": "內部上傳",
     "site_id": "網站ID",
-    "meta_password": "原資料密碼",
+    "meta_password": "元信息密碼",
     "share_name": "分享名稱",
     "account": "帳號",
     "bearer_token": "Bearer Token",


### PR DESCRIPTION
- Update 'meta_password' translation in zh-cn.json and zh-hant.json
- Change '原数据密码' to '元信息密码' in Simplified Chinese
- Change '原資料密碼' to '元信息密碼' in Traditional Chinese