### PR TITLE
fix: replace npm with pnpm in tauri build commands

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeBuildCommand": "npm run build",
-    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "pnpm run build",
+    "beforeDevCommand": "pnpm run dev",
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173"
   },


### PR DESCRIPTION
According to the README, this project suggests using `pnpm` for development.