### PR TITLE
fix：请尝试重启程序，并记录控制台错误信息向开发者反馈,Error:TypeError: Failed to execute 'fetc…

### DIFF
--- a/src/utils/openlist/openlist.ts
+++ b/src/utils/openlist/openlist.ts
@@ -11,7 +11,18 @@ import { nmConfig } from "../../services/config"
 async function getOpenlistToken() {
     const resultStr = await runCmd('openlist', ['admin', 'token', ...addParams()])
     const mark = 'Admin token:'
-    return resultStr.substring(resultStr.indexOf(mark) + mark.length).split(' ').join('')
+    const startIndex = resultStr.indexOf(mark)
+    if (startIndex === -1) {
+        console.error('getOpenlistToken: Failed to find "Admin token:" in output')
+        return ''
+    }
+    
+    // 提取 "Admin token:" 之后的内容，并只取第一行
+    const tokenPart = resultStr.substring(startIndex + mark.length)
+    const firstLine = tokenPart.split('\n')[0].trim()
+    
+    console.log('getOpenlistToken: Extracted token length:', firstLine.length)
+    return firstLine
 }
 
 async function setOpenlistPass(pass:string){


### PR DESCRIPTION
修复前 :
<img width="1348" height="648" alt="请尝试重启程序，并记录控制台错误信息向开发者反馈,ErrorTypeErrorFailed" src="https://github.com/user-attachments/assets/79e01121-c818-49db-a997-898ddb344679" />

关键日志：Headers: {"Authorization":"openlist-6d97cf79-36e9-4f01-b564-77105acc7d679bC6x49oLrmVKSHwPWNr5IuGjSHlVecqWcRanmbCUCurDmzzvdQZbJ5HTeoF2hk4\n\u001b[36mINFO\u001b[0m[2026-02-0817:25:28]readingconfigfile:...

分析:Authorization header 包含了整个命令行输出，包括多行文本和 ANSI 颜色代码！
这导致 fetch 抛出 "Invalid value" 错误，因为 HTTP header 不能包含换行符或控制字符，

结论：问题在 openlist.ts   getOpenlistToken() 函数，它没有正确提取 token

修复内容：getOpenlistToken() 函数
只提取 token 所在的第一行
移除多余的日志和控制字符
添加错误处理

Before fix:  
<img width="1348" height="648" alt="Please try restarting the program and record the console error information to report to the developer, ErrorTypeErrorFailed" src="https://github.com/user-attachments/assets/79e01121-c818-49db-a997-898ddb344679" />

Key log: Headers: {"Authorization":"openlist-6d97cf79-36e9-4f01-b564-77105acc7d679bC6x49oLrmVKSHwPWNr5IuGjSHlVecqWcRanmbCUCurDmzzvdQZbJ5HTeoF2hk4\n\u001b[36mINFO\u001b[0m[2026-02-0817:25:28]readingconfigfile:...

Analysis: The Authorization header contains the entire command line output, including multi-line text and ANSI color codes! This causes fetch to throw an "Invalid value" error because HTTP headers cannot contain newline characters or control characters.

Conclusion: The issue is in the `getOpenlistToken()` function in openlist.ts, which does not correctly extract the token.

Fixes:  
- Modify the `getOpenlistToken()` function to extract only the first line containing the token.  
- Remove excess logs and control characters.  
- Add error handling.